### PR TITLE
Converting empty uri path to / in aws_options

### DIFF
--- a/lib/cloud_providers/cloud_provider.rb
+++ b/lib/cloud_providers/cloud_provider.rb
@@ -63,6 +63,7 @@ module CloudProviders
 
     def maybe(action_description, default='Y', &block)
       puts "About to #{action_description}. Type 'Y' to do this, 'N' to skip. #{default} will be chosen within 10 seconds."
+      line = nil
       begin
         Timeout::timeout(10) do
           line = $stdin.readline

--- a/lib/cloud_providers/ec2/ec2.rb
+++ b/lib/cloud_providers/ec2/ec2.rb
@@ -386,7 +386,7 @@ module CloudProviders
       { :access_key_id    => access_key, 
         :secret_access_key=> secret_access_key, 
         :use_ssl          => (uri.scheme=='https'), 
-        :path             => uri.path, 
+        :path             => (uri.path.empty? ? '/' : uri.path), 
         :host             => uri.host,
         :port             => uri.port
       }.merge(opts)


### PR DESCRIPTION
Hello,

I added an expression in ec2.rb in aws_opions to avoid an empty string as option[:path]. 
E. g. EC2_URL=https://ec2.us-east-1.amazonaws.com (without the appended /) would result in "" for the :path. Now options[:path] path would return the standard value '/'. This prevents poolparty from crashing in case you forget the '/' at the end of EC2_URL.

Regards,
Philipp
